### PR TITLE
Implement message limit in conversation storage, ensuring only the la…

### DIFF
--- a/utils/app/conversation.ts
+++ b/utils/app/conversation.ts
@@ -2,6 +2,8 @@ import toast from 'react-hot-toast';
 
 import { Conversation, Role } from '@/types/chat';
 
+const MAX_MESSAGES_PER_CONVERSATION = 20;
+
 export const updateConversation = (
   updatedConversation: Conversation,
   allConversations: Conversation[],
@@ -25,9 +27,15 @@ export const updateConversation = (
 
 export const saveConversation = (conversation: Conversation) => {
   try {
+    // Limit messages in the selected conversation to maximum 20, keeping the most recent ones
+    const trimmedConversation = {
+      ...conversation,
+      messages: conversation.messages.slice(-MAX_MESSAGES_PER_CONVERSATION)
+    };
+    
     sessionStorage.setItem(
       'selectedConversation',
-      JSON.stringify(conversation),
+      JSON.stringify(trimmedConversation),
     );
   } catch (error) {
     if (error instanceof DOMException && error.name === 'QuotaExceededError') {
@@ -45,7 +53,7 @@ export const saveConversations = (conversations: Conversation[]) => {
     // Limit messages in the conversation to maximum 20, keeping the most recent ones
     const conversationsWithLimitedMessages = latestConversation.map(conversation => ({
       ...conversation,
-      messages: conversation.messages.slice(-20)
+      messages: conversation.messages.slice(-MAX_MESSAGES_PER_CONVERSATION)
     }));
     
     sessionStorage.setItem(


### PR DESCRIPTION
…test 20 messages are retained for both individual and all conversations.

## Description
<!-- Note: The pull request title will be included in the CHANGELOG. -->
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". All PRs should have an issue they close-->
Closes

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit-UI/blob/main/CODE-OF-CONDUCT.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.
