### PR TITLE
Optimize conversation storage by removing intermediate steps from mes…

### DIFF
--- a/utils/app/conversation.ts
+++ b/utils/app/conversation.ts
@@ -25,9 +25,18 @@ export const updateConversation = (
 
 export const saveConversation = (conversation: Conversation) => {
   try {
+    // Strip intermediateSteps to reduce storage size
+    const conversationForStorage = {
+      ...conversation,
+      messages: conversation.messages.map(msg => {
+        const { intermediateSteps, ...messageWithoutSteps } = msg as any;
+        return messageWithoutSteps;
+      })
+    };
+    
     sessionStorage.setItem(
       'selectedConversation',
-      JSON.stringify(conversation),
+      JSON.stringify(conversationForStorage),
     );
   } catch (error) {
     if (error instanceof DOMException && error.name === 'QuotaExceededError') {
@@ -39,9 +48,18 @@ export const saveConversation = (conversation: Conversation) => {
 
 export const saveConversations = (conversations: Conversation[]) => {
   try {
+    // Strip intermediateSteps from all conversations to reduce storage size
+    const conversationsForStorage = conversations.map(conv => ({
+      ...conv,
+      messages: conv.messages.map(msg => {
+        const { intermediateSteps, ...messageWithoutSteps } = msg as any;
+        return messageWithoutSteps;
+      })
+    }));
+    
     sessionStorage.setItem(
       'conversationHistory',
-      JSON.stringify(conversations),
+      JSON.stringify(conversationsForStorage),
     );
   } catch (error) {
     if (error instanceof DOMException && error.name === 'QuotaExceededError') {


### PR DESCRIPTION
…sages

- Updated `saveConversation` and `saveConversations` functions to strip `intermediateSteps` from messages before saving to sessionStorage, reducing storage size.

## Description
<!-- Note: The pull request title will be included in the CHANGELOG. -->
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". All PRs should have an issue they close-->
Closes

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit-UI/blob/main/CODE-OF-CONDUCT.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.
